### PR TITLE
Bring NonMax* closer to parity with NonZero*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup default ${{ matrix.rust_version }}
 
+    - name: Update Rust toolchain
+      run: rustup update ${{ matrix.rust_version }}
+      if: matrix.rust_version == 'stable'
+
     - name: Build
       run: cargo build --verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.46.0"]
+        rust_version: [stable, "1.47.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # nonmax Changelog
 
 ## Unreleased Changes
+* Raised MSRV to 1.47.0 to reduce `unsafe` by using `NonZero*::new`
 
 ## 0.4.0 (2020-09-27)
 * Raised MSRV to 1.46.0 to make more methods `const`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 * Raised MSRV to 1.47.0 to reduce `unsafe` by using `NonZero*::new`
 * Implement a bunch of traits that NonZero had but NonMax was missing
+* Added `NonMaxI128` and `NonMaxU128` support
 
 ## 0.4.0 (2020-09-27)
 * Raised MSRV to 1.46.0 to make more methods `const`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 * Raised MSRV to 1.47.0 to reduce `unsafe` by using `NonZero*::new`
+* Implement a bunch of traits that NonZero had but NonMax was missing
 
 ## 0.4.0 (2020-09-27)
 * Raised MSRV to 1.46.0 to make more methods `const`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ assert_eq!(oops, None);
 
 ### Minimum Supported Rust Version (MSRV)
 
-nonmax supports Rust 1.46.0 and newer. Until this library reaches 1.0,
+nonmax supports Rust 1.47.0 and newer. Until this library reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,22 +269,27 @@ macro_rules! impl_nonmax_from {
 impl_nonmax_from!(NonMaxU8, NonMaxU16);
 impl_nonmax_from!(NonMaxU8, NonMaxU32);
 impl_nonmax_from!(NonMaxU8, NonMaxU64);
+impl_nonmax_from!(NonMaxU8, NonMaxUsize);
 impl_nonmax_from!(NonMaxU16, NonMaxU32);
 impl_nonmax_from!(NonMaxU16, NonMaxU64);
+impl_nonmax_from!(NonMaxU16, NonMaxUsize);
 impl_nonmax_from!(NonMaxU32, NonMaxU64);
 
 // Non-max Signed -> Non-max Signed
 impl_nonmax_from!(NonMaxI8, NonMaxI16);
 impl_nonmax_from!(NonMaxI8, NonMaxI32);
 impl_nonmax_from!(NonMaxI8, NonMaxI64);
+impl_nonmax_from!(NonMaxI8, NonMaxIsize);
 impl_nonmax_from!(NonMaxI16, NonMaxI32);
 impl_nonmax_from!(NonMaxI16, NonMaxI64);
+impl_nonmax_from!(NonMaxI16, NonMaxIsize);
 impl_nonmax_from!(NonMaxI32, NonMaxI64);
 
 // Non-max Unsigned -> Non-max Signed
 impl_nonmax_from!(NonMaxU8, NonMaxI16);
 impl_nonmax_from!(NonMaxU8, NonMaxI32);
 impl_nonmax_from!(NonMaxU8, NonMaxI64);
+impl_nonmax_from!(NonMaxU8, NonMaxIsize);
 impl_nonmax_from!(NonMaxU16, NonMaxI32);
 impl_nonmax_from!(NonMaxU16, NonMaxI64);
 impl_nonmax_from!(NonMaxU32, NonMaxI64);
@@ -306,22 +311,27 @@ macro_rules! impl_smaller_from {
 impl_smaller_from!(u8, NonMaxU16);
 impl_smaller_from!(u8, NonMaxU32);
 impl_smaller_from!(u8, NonMaxU64);
+impl_smaller_from!(u8, NonMaxUsize);
 impl_smaller_from!(u16, NonMaxU32);
 impl_smaller_from!(u16, NonMaxU64);
+impl_smaller_from!(u16, NonMaxUsize);
 impl_smaller_from!(u32, NonMaxU64);
 
 // Signed -> Non-max Signed
 impl_smaller_from!(i8, NonMaxI16);
 impl_smaller_from!(i8, NonMaxI32);
 impl_smaller_from!(i8, NonMaxI64);
+impl_smaller_from!(i8, NonMaxIsize);
 impl_smaller_from!(i16, NonMaxI32);
 impl_smaller_from!(i16, NonMaxI64);
+impl_smaller_from!(i16, NonMaxIsize);
 impl_smaller_from!(i32, NonMaxI64);
 
 // Unsigned -> Non-max Signed
 impl_smaller_from!(u8, NonMaxI16);
 impl_smaller_from!(u8, NonMaxI32);
 impl_smaller_from!(u8, NonMaxI64);
+impl_smaller_from!(u8, NonMaxIsize);
 impl_smaller_from!(u16, NonMaxI32);
 impl_smaller_from!(u16, NonMaxI64);
 impl_smaller_from!(u32, NonMaxI64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ assert_eq!(oops, None);
 
 ## Minimum Supported Rust Version (MSRV)
 
-nonmax supports Rust 1.46.0 and newer. Until this library reaches 1.0,
+nonmax supports Rust 1.47.0 and newer. Until this library reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 */
@@ -59,13 +59,10 @@ macro_rules! nonmax {
             /// value.
             #[inline]
             pub const fn new(value: $primitive) -> Option<Self> {
-                if value == $primitive::max_value() {
-                    None
+                if let Some(v) = std::num::$non_zero::new(value ^ $primitive::max_value()) {
+                    Some(Self(v))
                 } else {
-                    let inner = unsafe {
-                        std::num::$non_zero::new_unchecked(value ^ $primitive::max_value())
-                    };
-                    Some(Self(inner))
+                    None
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,12 +244,14 @@ nonmax!(signed, NonMaxI8, NonZeroI8, i8);
 nonmax!(signed, NonMaxI16, NonZeroI16, i16);
 nonmax!(signed, NonMaxI32, NonZeroI32, i32);
 nonmax!(signed, NonMaxI64, NonZeroI64, i64);
+nonmax!(signed, NonMaxI128, NonZeroI128, i128);
 nonmax!(signed, NonMaxIsize, NonZeroIsize, isize);
 
 nonmax!(unsigned, NonMaxU8, NonZeroU8, u8);
 nonmax!(unsigned, NonMaxU16, NonZeroU16, u16);
 nonmax!(unsigned, NonMaxU32, NonZeroU32, u32);
 nonmax!(unsigned, NonMaxU64, NonZeroU64, u64);
+nonmax!(unsigned, NonMaxU128, NonZeroU128, u128);
 nonmax!(unsigned, NonMaxUsize, NonZeroUsize, usize);
 
 // https://doc.rust-lang.org/stable/src/core/convert/num.rs.html#383-407
@@ -269,30 +271,42 @@ macro_rules! impl_nonmax_from {
 impl_nonmax_from!(NonMaxU8, NonMaxU16);
 impl_nonmax_from!(NonMaxU8, NonMaxU32);
 impl_nonmax_from!(NonMaxU8, NonMaxU64);
+impl_nonmax_from!(NonMaxU8, NonMaxU128);
 impl_nonmax_from!(NonMaxU8, NonMaxUsize);
 impl_nonmax_from!(NonMaxU16, NonMaxU32);
 impl_nonmax_from!(NonMaxU16, NonMaxU64);
+impl_nonmax_from!(NonMaxU16, NonMaxU128);
 impl_nonmax_from!(NonMaxU16, NonMaxUsize);
 impl_nonmax_from!(NonMaxU32, NonMaxU64);
+impl_nonmax_from!(NonMaxU32, NonMaxU128);
+impl_nonmax_from!(NonMaxU64, NonMaxU128);
 
 // Non-max Signed -> Non-max Signed
 impl_nonmax_from!(NonMaxI8, NonMaxI16);
 impl_nonmax_from!(NonMaxI8, NonMaxI32);
 impl_nonmax_from!(NonMaxI8, NonMaxI64);
+impl_nonmax_from!(NonMaxI8, NonMaxI128);
 impl_nonmax_from!(NonMaxI8, NonMaxIsize);
 impl_nonmax_from!(NonMaxI16, NonMaxI32);
 impl_nonmax_from!(NonMaxI16, NonMaxI64);
+impl_nonmax_from!(NonMaxI16, NonMaxI128);
 impl_nonmax_from!(NonMaxI16, NonMaxIsize);
 impl_nonmax_from!(NonMaxI32, NonMaxI64);
+impl_nonmax_from!(NonMaxI32, NonMaxI128);
+impl_nonmax_from!(NonMaxI64, NonMaxI128);
 
 // Non-max Unsigned -> Non-max Signed
 impl_nonmax_from!(NonMaxU8, NonMaxI16);
 impl_nonmax_from!(NonMaxU8, NonMaxI32);
 impl_nonmax_from!(NonMaxU8, NonMaxI64);
+impl_nonmax_from!(NonMaxU8, NonMaxI128);
 impl_nonmax_from!(NonMaxU8, NonMaxIsize);
 impl_nonmax_from!(NonMaxU16, NonMaxI32);
 impl_nonmax_from!(NonMaxU16, NonMaxI64);
+impl_nonmax_from!(NonMaxU16, NonMaxI128);
 impl_nonmax_from!(NonMaxU32, NonMaxI64);
+impl_nonmax_from!(NonMaxU32, NonMaxI128);
+impl_nonmax_from!(NonMaxU64, NonMaxI128);
 
 // https://doc.rust-lang.org/stable/src/core/convert/num.rs.html#383-407
 macro_rules! impl_smaller_from {
@@ -311,30 +325,42 @@ macro_rules! impl_smaller_from {
 impl_smaller_from!(u8, NonMaxU16);
 impl_smaller_from!(u8, NonMaxU32);
 impl_smaller_from!(u8, NonMaxU64);
+impl_smaller_from!(u8, NonMaxU128);
 impl_smaller_from!(u8, NonMaxUsize);
 impl_smaller_from!(u16, NonMaxU32);
 impl_smaller_from!(u16, NonMaxU64);
+impl_smaller_from!(u16, NonMaxU128);
 impl_smaller_from!(u16, NonMaxUsize);
 impl_smaller_from!(u32, NonMaxU64);
+impl_smaller_from!(u32, NonMaxU128);
+impl_smaller_from!(u64, NonMaxU128);
 
 // Signed -> Non-max Signed
 impl_smaller_from!(i8, NonMaxI16);
 impl_smaller_from!(i8, NonMaxI32);
 impl_smaller_from!(i8, NonMaxI64);
+impl_smaller_from!(i8, NonMaxI128);
 impl_smaller_from!(i8, NonMaxIsize);
 impl_smaller_from!(i16, NonMaxI32);
 impl_smaller_from!(i16, NonMaxI64);
+impl_smaller_from!(i16, NonMaxI128);
 impl_smaller_from!(i16, NonMaxIsize);
 impl_smaller_from!(i32, NonMaxI64);
+impl_smaller_from!(i32, NonMaxI128);
+impl_smaller_from!(i64, NonMaxI128);
 
 // Unsigned -> Non-max Signed
 impl_smaller_from!(u8, NonMaxI16);
 impl_smaller_from!(u8, NonMaxI32);
 impl_smaller_from!(u8, NonMaxI64);
+impl_smaller_from!(u8, NonMaxI128);
 impl_smaller_from!(u8, NonMaxIsize);
 impl_smaller_from!(u16, NonMaxI32);
 impl_smaller_from!(u16, NonMaxI64);
+impl_smaller_from!(u16, NonMaxI128);
 impl_smaller_from!(u32, NonMaxI64);
+impl_smaller_from!(u32, NonMaxI128);
+impl_smaller_from!(u64, NonMaxI128);
 
 fn parse_int_error_overflow() -> std::num::ParseIntError {
     use std::str::FromStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,9 @@ mod ops {
 
     #[test]
     fn bitand_unsigned() {
-        for left in 0..=255 {
+        for left in 0..=u8::MAX {
             let nmleft = NonMaxU8::new(left);
-            for right in 0..=255 {
+            for right in 0..=u8::MAX {
                 let nmright = NonMaxU8::new(right);
                 let vanilla = left & right;
 
@@ -399,9 +399,9 @@ mod ops {
 
     #[test]
     fn bitand_signed() {
-        for left in -128..=127 {
+        for left in i8::MIN..=i8::MAX {
             let nmleft = NonMaxI8::new(left);
-            for right in -128..=127 {
+            for right in i8::MIN..=i8::MAX {
                 let nmright = NonMaxI8::new(right);
                 let vanilla = left & right;
                 if let (Some(nmleft), Some(nmright)) = (nmleft, nmright) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! nonmax {
                 let some = $nonmax::new(19).unwrap();
                 let max1 = $nonmax::new($primitive::max_value() - 1).unwrap();
                 for value in [zero, some, max1].iter().copied() {
-                    assert_eq!(format!("{}",   value.get()), format!("{}",   value)); // Display
+                    assert_eq!(format!("{}", value.get()), format!("{}", value)); // Display
                     assert_eq!(format!("{:?}", value.get()), format!("{:?}", value)); // Debug
                     assert_eq!(format!("{:b}", value.get()), format!("{:b}", value)); // Binary
                     assert_eq!(format!("{:o}", value.get()), format!("{:o}", value)); // Octal
@@ -379,9 +379,9 @@ mod ops {
 
     #[test]
     fn bitand_unsigned() {
-        for left in 0 ..= 255 {
+        for left in 0..=255 {
             let nmleft = NonMaxU8::new(left);
-            for right in 0 ..= 255 {
+            for right in 0..=255 {
                 let nmright = NonMaxU8::new(right);
                 let vanilla = left & right;
 
@@ -400,9 +400,9 @@ mod ops {
 
     #[test]
     fn bitand_signed() {
-        for left in -128 ..= 127 {
+        for left in -128..=127 {
             let nmleft = NonMaxI8::new(left);
-            for right in -128 ..= 127 {
+            for right in -128..=127 {
                 let nmright = NonMaxI8::new(right);
                 let vanilla = left & right;
                 if let (Some(nmleft), Some(nmright)) = (nmleft, nmright) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,7 +372,6 @@ fn try_from_int_error_overflow() -> std::num::TryFromIntError {
     u8::try_from(999u32).unwrap_err()
 }
 
-
 #[cfg(test)]
 mod ops {
     use super::*;


### PR DESCRIPTION
Bumped MSRV to 1.47.0 so I could get rid of the `unsafe` in `new`, but that could be reverted.  And since I had a fork going *anyways*, I implemented a bunch of traits that were implemented on `NonZero*` but not `NonMax*`, and added `NonMax*128` ;)