### PR TITLE
Eliminate `unsafe` in `new`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,15 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.46.0"]
+        rust_version: [stable, "1.47.0"]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Setup Rust toolchain
-      run: rustup default ${{ matrix.rust_version }}
+      run: |
+        rustup default ${{ matrix.rust_version }}
+        rustup update ${{ matrix.rust_version }}
 
     - name: Build (no_std)
       run: cargo build --verbose --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # nonmax Changelog
 
 ## Unreleased Changes
+* Raised MSRV to 1.47.0 to eliminate `unsafe` in `new`.
 * Added `NonMaxI128` and `NonMaxU128` support
 * Implemented `std::convert::[Try]From` for `NonMax*` & primitive types to match `NonZero*`
 * Implemented `std::fmt::{Display, Binary, Octal, LowerHex, UpperHex}` to match `NonZero*`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,13 +128,9 @@ macro_rules! nonmax {
             /// value.
             #[inline]
             pub const fn new(value: $primitive) -> Option<Self> {
-                if value == $primitive::max_value() {
-                    None
-                } else {
-                    let inner = unsafe {
-                        core::num::$non_zero::new_unchecked(value ^ $primitive::max_value())
-                    };
-                    Some(Self(inner))
+                match core::num::$non_zero::new(value ^ $primitive::max_value()) {
+                    None => None,
+                    Some(value) => Some(Self(value)),
                 }
             }
 


### PR DESCRIPTION
So, the disassembly I mentioned earlier:
* [Godbolt](https://rust.godbolt.org/z/Ghzh3G) (easy to muck with the `--cfg safe` in the command line to see they disassemble the same)
* [Safe-only Playground](https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=6edfebe866874503910b60b7793cbff6) (can also disassemble)
```
example::NonMaxU64::new:
        mov     rax, rdi
        not     rax
        ret

example::NonMaxI64::new:
        movabs  rax, 9223372036854775807
        xor     rax, rdi
        ret
```

Debug disassembly does introduce a new branch, and this does bump MSRV - just to get rid of a single `unsafe` after having added several - so maybe this PR isn't worth merging.  But it *would* be one less thing to scrutinize, for other weirdos like me who might be using <code>[cargo crev](https://github.com/crev-dev/cargo-crev) crate review ...</code>