### PR TITLE
Added optional support for serde.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 * Implemented `Default` for `NonMax*`.
+* Added serialization/deserialization with `serde` when the corresponding feature is enabled.
 
 ## 0.5.0 (2020-10-18)
 * Raised MSRV to 1.47.0 to eliminate `unsafe` in `new`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ default = ["std"]
 std = []
 
 [dependencies]
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+bincode = "1.3"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ assert_eq!(oops, None);
 [`TryFromIntError`]. Disable this feature for
 [`#![no_std]`](https://rust-embedded.github.io/book/intro/no-std.html) support.
 
+* `serde`: implements the `Serialize` and `Deserialize` traits from [`serde`](https://crates.io/crates/serde).
+
 ### Minimum Supported Rust Version (MSRV)
 
 nonmax supports Rust 1.47.0 and newer. Until this library reaches 1.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ macro_rules! nonmax {
             #[test]
             #[cfg(feature = "serde")]
             fn serde() {
-                for value in [0, 19, $primitive::MAX - 1] {
+                for &value in [0, 19, $primitive::MAX - 1].iter() {
                     let nonmax_value = $nonmax::new(value).unwrap();
                     let encoded: Vec<u8> = bincode::serialize(&nonmax_value).unwrap();
                     let decoded: $nonmax = bincode::deserialize(&encoded[..]).unwrap();


### PR DESCRIPTION
This PR simply adds optional `serde` support. For ease of interpretation, especially with formats such as JSON, data are stored in the user-facing format, not in the internal format.