### PR TITLE
Allow `serde` dependency to be used in `no_std` contexts.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ macro_rules! nonmax {
                 D: serde::Deserializer<'de>,
             {
                 let value = $primitive::deserialize(deserializer)?;
-                use std::convert::TryFrom;
+                use core::convert::TryFrom;
                 Self::try_from(value).map_err(serde::de::Error::custom)
             }
         }


### PR DESCRIPTION
`serde` enables its `std` feature by default, so pulling in `serde` with its default dependencies unfortunately breaks `no_std` builds. This PR simply disables the `std` feature on `serde`, allowing it to be used with the `serde` feature in `no_std` contexts.

This was a simple change, considering the `serde` trait implementations in this crate don't use anything exclusively from the standard library.