### PR TITLE
Fix test: serde test also requires std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ macro_rules! nonmax {
             }
 
             #[test]
-            #[cfg(feature = "serde")]
+            #[cfg(all(feature = "serde", feature = "std"))]
             fn serde() {
                 for &value in [0, 19, $primitive::MAX - 1].iter() {
                     let nonmax_value = NonMax::<$primitive>::new(value).unwrap();


### PR DESCRIPTION
Hi. I am packaging your lib for Debian, and found this test issue.

This serde test was declared as requiring the "serde" feature only.
But it uses Vec, that depends on std allocator.